### PR TITLE
ci: add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build and test
+        run: ./mvnw clean verify

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/tmclnk/joco/actions/workflows/ci.yml/badge.svg)](https://github.com/tmclnk/joco/actions/workflows/ci.yml)
+
 # joco
 
 A lightweight clone of opencommit that generates meaningful commit messages using Ollama local LLMs.


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that runs on every push
- Build and test using Maven wrapper with Java 21
- Add CI status badge to README

## Test plan
- [x] Push branch and verify workflow runs
- [ ] Confirm badge updates after successful run

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)