### PR TITLE
fix: use correct GraalVM distribution name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   JAVA_VERSION: '21'
-  GRAALVM_DISTRIBUTION: 'graalce'
+  GRAALVM_DISTRIBUTION: 'graalvm-community'
 
 jobs:
   # Build the platform-independent fat JAR


### PR DESCRIPTION
Fix GraalVM setup by using 'graalvm-community' instead of 'graalce'